### PR TITLE
rustのバージョンアップ

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.88.0"
 components = ["rustc", "cargo", "rustfmt", "clippy"]
 profile = "minimal"
 targets = []


### PR DESCRIPTION
バージョンを1.80.0から1.88.0に変更